### PR TITLE
Mec sequence, Laser

### DIFF
--- a/experiments/lu5717.py
+++ b/experiments/lu5717.py
@@ -1,0 +1,311 @@
+import logging
+from bluesky.plans import scan
+import bluesky.plan_stubs as bps 
+import bluesky.preprocessors as bpp
+#from bluesky.utils import Msg
+#from ophyd.sim import motor
+from ophyd import (Device, EpicsSignal, EpicsSignalRO, Component as Cpt)
+from mec.db import RE
+from mec.db import seq, daq
+from mec.db import mec_pulsepicker as pp
+from mec.db import tomo_motor, lamo_motor
+
+logger = logging.getLogger(__name__)
+
+class piAxis(Device):
+    sens_raw = Cpt(EpicsSignalRO, ':SENSORPOSGET')
+    sens_filt = Cpt(EpicsSignalRO, ':SENSORPOSFILT')
+
+    servo_pos_set = Cpt(EpicsSignal, ':SERVOPOSSET')
+    servo_pos_get = Cpt(EpicsSignal, ':SERVOPOSGET')
+
+    openloop_pos_set = Cpt(EpicsSignal, ':OPENLOOPPOSSET')
+    openloop_pos_get = Cpt(EpicsSignalRO, ':OPENLOOPPOSGET')
+
+    velocity_set = Cpt(EpicsSignal, ':VELOCITYSET')
+    velocity_get = Cpt(EpicsSignalRO, ':VELOCITYGET')
+
+    status = Cpt(EpicsSignalRO, ':MOVING')
+    servo_mode = Cpt(EpicsSignal, ':SERVOMODESET')
+
+    def mv(self, pos):
+        """Move the piezo axis to the specified position. The motion command
+        will be closed-loop or open-loop, depending on the current mode of the
+        piezo controller."""
+        if self.mode == 1:
+            self.servo_pos_set.put(pos)
+        elif self.mode == 0:
+            self.openloop_pos_set.put(pos) 
+        else:
+            raise ValueError("Unrecognized piezo mode {}!".format(self.mode))
+
+    def wm(self):
+        """Return the current piezo position. The position returned will be  
+        closed-loop or open-loop, depending on the current mode of the piezo
+        controller."""
+        if self.mode == 1:
+            return self.servo_pos_get.get()
+        elif self.mode == 0:
+            return self.openloop_pos_get.get() 
+        else:
+            raise ValueError("Unrecognized piezo mode {}!".format(self.mode))
+
+    @property
+    def mode(self):
+        """Get the mode of the piezo axis. 0 = Open loop, 1 = closed loop."""
+        return self.servo_mode.get()
+
+    @mode.setter
+    def mode(self, m):
+        """Set the mode of the piezo axis. 0 = Open loop, 1 = closed loop."""
+        self.servo_mode.put(int(m))
+
+    @property
+    def velocity(self):
+        """Get the current velocity of the piezo axis."""
+        v = self.velocity_get.get()
+        return v
+
+    @velocity.setter
+    def velocity(self, velo):
+        """Set the velocity of the piezo axis."""
+        self.velocity_set.put(velo)
+
+    @property
+    def moving(self):
+        """Return the moving status of the piezo axis."""
+        moving = self.status.get()
+        if moving == 1:
+            return True
+        else:
+            return False
+
+
+class piHera(Device):
+    """Class for the PI Hera piezo controller."""
+    ch1 = Cpt(piAxis, ':01')
+    ch2 = Cpt(piAxis, ':02')
+    ch3 = Cpt(piAxis, ':03')
+
+    def wm(self):
+        """Return the positions for each channel of the controller. Gives a
+        list of the channel positions: [ch1, ch2, ch3]."""
+        c1_pos = self.ch1.wm()
+        c2_pos = self.ch2.wm()
+        c3_pos = self.ch3.wm()
+    
+        return [c1_pos, c2_pos, c3_pos]
+
+    def mv(self, positions):
+        """Move the piezo axes to the specified positions. Takes a list of 
+        three positions, corresponding to ch1, ch2 and ch3, respectively."""
+        self.ch1.mv(positions[0])
+        self.ch2.mv(positions[1])
+        self.ch3.mv(positions[2])
+
+    @property
+    def mode(self):
+        """Function to return the servo mode of all 3 channels. 0 == Open loop,
+        1 == Closed loop."""
+        return [self.ch1.mode, self.ch2.mode, self.ch3.mode]
+
+    @mode.setter
+    def mode(self, mode):
+        """Function to set the servo mode of all 3 channels. 0 == Open loop,
+        1 == Closed loop."""
+        self.ch1.mode(mode)
+        self.ch2.mode(mode)
+        self.ch3.mode(mode)
+
+    @property
+    def moving(self):
+        """Returns the moving status of the controller. If any axis is
+        currently moving, then this return True, else False."""
+        if self.ch1.moving or self.ch2.moving or self.ch3.moving:
+            return True
+        else:
+            return False
+
+
+class User():
+
+    pi = piHera('MEC:MZM', name='PI Hera controller')
+    #_tomo_motor = motor # Sim motor for testing
+    _tomo_motor = tomo_motor # Tomography motor, defined in questionnaire
+    _lamo_motor = lamo_motor # Laminography motor, defined in questionnaire
+
+    def tomo_scan(self, tomo_start, tomo_end, npoints, ndaq=1000, record=True):
+        """Return a tomography scan plan.
+
+        Usage
+        -----
+        p = x.tomo_scan(tomo_start, tomo_end, npoints, ndaq=1000, record=True)
+        RE(p)
+
+        Parameters
+        ----------
+
+        tomo_start : float
+            Starting position of the tomography scan (in degrees).
+
+        tomo_end : float
+            Ending position of the tomography scan (in degrees).
+
+        npoints : int
+            Number of points to divide the tomography scan into. Separation
+            between scan points is equal to (tomo_end - tomo_start)/num_points.
+
+        ndaq : int
+            Number of points to record for each tomography position.
+            Defaults to 1000.
+
+        record: bool
+            Whether or not to record in the DAQ. Defaults to True.
+
+        Examples
+        --------
+
+        # Use default DAQ settings
+        tomo_scan(75.0, 85.0, 10)
+
+        # Record a different number of data points per tomography position
+        tomo_scan(75.0, 85.0, 10, ndaq=1500)
+
+        # Don't record
+        tomo_scan(75.0, 85.0, 10, record=False)
+        """
+        # Log stuff
+        logging.debug("Returning a tomography scan with the following parameters:")
+        logging.debug("motor: %s", self._tomo_motor)
+        logging.debug("tomo_start: %s", tomo_start)
+        logging.debug("tomo_end: %s", tomo_end)
+        logging.debug("npoints: %s", npoints)
+        logging.debug("record: %s", record)
+
+        # Return the plan 
+        return self.__1DScan(self._tomo_motor, tomo_start, tomo_end, npoints,
+                      ndaq, record)
+    
+    
+    def lamo_scan(self, lamo_start, lamo_end, npoints, ndaq=1000, record=True):
+        """Return a laminography scan plan.
+
+        Usage
+        -----
+        p = x.lamo_scan(lamo_start, lamo_end, npoints, ndaq=1000, record=True)
+        RE(p)
+
+        Parameters
+        ----------
+
+        lamo_start : float
+            Starting position of the laminography scan (in degrees).
+
+        lamo_end : float
+            Ending position of the laminography scan (in degrees).
+
+        npoints : int
+            Number of points to divide the laminography scan into. Separation
+            between scan points is equal to (lamo_end - lamo_start)/num_points.
+
+        ndaq : int
+            Number of points to record for each laminography position.
+            Defaults to 1000.
+
+        record: bool
+            Whether or not to record in the DAQ. Defaults to True.
+
+        Examples
+        --------
+
+        # Use default DAQ settings
+        x.lamo_scan(75.0, 85.0, 10)
+
+        # Record a different number of data points per laminography position
+        x.lamo_scan(75.0, 85.0, 10, ndaq=1500)
+
+        # Don't record
+        x.lamo_scan(75.0, 85.0, 10, record=False)
+        """
+        # Log stuff
+        logging.debug("Returning laminography scan with the following parameters:")
+        logging.debug("motor: %s", self._lamo_motor)
+        logging.debug("lamo_start: %s", lamo_start)
+        logging.debug("lamo_end: %s", lamo_end)
+        logging.debug("npoints: %s", npoints)
+        logging.debug("record: %s", record)
+
+        # Return the plan 
+        return self.__1DScan(self._lamo_motor, lamo_start, lamo_end, npoints,
+                      ndaq, record)
+
+
+    def __1DScan(self, motor, start, end, npoints, ndaq, record):
+        # Setup the event sequencer for the scan
+        logging.debug("Setting up the sequencer for %s daq points", ndaq)
+        self.__setup_sequencer(ndaq)
+
+        # Setup the pulse picker
+        if pp.mode.get() == 3:
+            logging.debug("The pulse picker is already in burst mode")
+        else:    
+            logging.debug("Setting up the pulse picker for burst mode")
+            pp.burst(wait=True)
+
+        # Setup the DAQ
+        daq.record = record
+        daq.configure(events=ndaq)
+        bps.configure(daq, events=ndaq) # For plan introspection
+
+        # Add sequencer, DAQ to detectors for scan
+        dets = [daq, seq]
+
+        # Log stuff
+        logging.debug("Returning __1DScan with the following parameters:")
+        logging.debug("motor: {}".format(motor))
+        logging.debug("start: {}".format(start))
+        logging.debug("end: {}".format(end))
+        logging.debug("npoints: {}".format(npoints))
+        logging.debug("ndaq: {}".format(ndaq))
+        logging.debug("record: {}".format(record))
+        logging.debug("detectors: {}".format(dets))
+    
+        # Return the plan 
+        scan_plan = scan(dets,
+               motor, start, end,
+               npoints)
+
+        final_plan = bpp.finalize_wrapper(scan_plan, self._cleanup_plan())
+
+        return final_plan 
+
+
+    def __setup_sequencer(self, num_points):
+        # Do smart stuff with the sequencer now
+
+        # PP Open line
+        pp_open = [[168, 0, 0, 0]] # Open pulse picker, no delay
+
+        # Scan trigger
+        pi_line = [[170, 2, 0, 0]] # Give PP 2 beam delays to open 
+
+        # Add most of the daq triggers
+        daq_lines = [ [169, 1, 0, 0] for i in range(num_points-1) ]
+
+        # PP Close line
+        pp_close = [[168, 0, 0, 0]] # Close pulse picker, no delay
+
+        # Add last DAQ event
+        last_daq = [[169, 1, 0, 0]] 
+
+        s = pp_open + pi_line + daq_lines + pp_close + last_daq
+
+        sequence = [ arr for arr in zip(*s) ]
+
+        seq.sequence.put_seq(sequence)
+
+
+    def _cleanup_plan(self):
+        # Plan to do some cleanup at the end of a scan
+        yield from bps.abs_set(pp.cmd_reset, 1) # Reset pulse picker
+        yield from bps.abs_set(pp.cmd_close, 1) # Close pulse picker

--- a/experiments/lu5717.py
+++ b/experiments/lu5717.py
@@ -1,5 +1,7 @@
+import numpy as np
+import time
 import logging
-from bluesky.plans import scan
+from bluesky.plans import scan, count
 import bluesky.plan_stubs as bps 
 import bluesky.preprocessors as bpp
 #from bluesky.utils import Msg
@@ -9,6 +11,7 @@ from mec.db import RE
 from mec.db import seq, daq
 from mec.db import mec_pulsepicker as pp
 from mec.db import tomo_motor, lamo_motor
+from mec.db import tgx, tgy, tgz
 
 logger = logging.getLogger(__name__)
 
@@ -55,10 +58,10 @@ class piAxis(Device):
         """Get the mode of the piezo axis. 0 = Open loop, 1 = closed loop."""
         return self.servo_mode.get()
 
-    @mode.setter
-    def mode(self, m):
-        """Set the mode of the piezo axis. 0 = Open loop, 1 = closed loop."""
-        self.servo_mode.put(int(m))
+#    @mode.setter
+#    def mode(self, m):
+#        """Set the mode of the piezo axis. 0 = Open loop, 1 = closed loop."""
+#        self.servo_mode.put(int(m))
 
     @property
     def velocity(self):
@@ -87,6 +90,10 @@ class piHera(Device):
     ch2 = Cpt(piAxis, ':02')
     ch3 = Cpt(piAxis, ':03')
 
+    x = ch1
+    y = ch3
+    z = ch2
+
     def wm(self):
         """Return the positions for each channel of the controller. Gives a
         list of the channel positions: [ch1, ch2, ch3]."""
@@ -109,13 +116,13 @@ class piHera(Device):
         1 == Closed loop."""
         return [self.ch1.mode, self.ch2.mode, self.ch3.mode]
 
-    @mode.setter
-    def mode(self, mode):
-        """Function to set the servo mode of all 3 channels. 0 == Open loop,
-        1 == Closed loop."""
-        self.ch1.mode(mode)
-        self.ch2.mode(mode)
-        self.ch3.mode(mode)
+#    @mode.setter
+#    def mode(self, mode):
+#        """Function to set the servo mode of all 3 channels. 0 == Open loop,
+#        1 == Closed loop."""
+#        self.ch1.mode(mode)
+#        self.ch2.mode(mode)
+#        self.ch3.mode(mode)
 
     @property
     def moving(self):
@@ -134,12 +141,12 @@ class User():
     _tomo_motor = tomo_motor # Tomography motor, defined in questionnaire
     _lamo_motor = lamo_motor # Laminography motor, defined in questionnaire
 
-    def tomo_scan(self, tomo_start, tomo_end, npoints, ndaq=1000, record=True):
+    def tomo_scan(self, tomo_start, tomo_end, npoints, ndaq, record=True):
         """Return a tomography scan plan.
 
         Usage
         -----
-        p = x.tomo_scan(tomo_start, tomo_end, npoints, ndaq=1000, record=True)
+        p = x.tomo_scan(tomo_start, tomo_end, npoints, ndaq, record=True)
         RE(p)
 
         Parameters
@@ -157,7 +164,6 @@ class User():
 
         ndaq : int
             Number of points to record for each tomography position.
-            Defaults to 1000.
 
         record: bool
             Whether or not to record in the DAQ. Defaults to True.
@@ -187,12 +193,12 @@ class User():
                       ndaq, record)
     
     
-    def lamo_scan(self, lamo_start, lamo_end, npoints, ndaq=1000, record=True):
+    def lamo_scan(self, lamo_start, lamo_end, npoints, ndaq, record=True):
         """Return a laminography scan plan.
 
         Usage
         -----
-        p = x.lamo_scan(lamo_start, lamo_end, npoints, ndaq=1000, record=True)
+        p = x.lamo_scan(lamo_start, lamo_end, npoints, ndaq, record=True)
         RE(p)
 
         Parameters
@@ -210,7 +216,6 @@ class User():
 
         ndaq : int
             Number of points to record for each laminography position.
-            Defaults to 1000.
 
         record: bool
             Whether or not to record in the DAQ. Defaults to True.
@@ -255,7 +260,7 @@ class User():
         # Setup the DAQ
         daq.record = record
         daq.configure(events=ndaq)
-        bps.configure(daq, events=ndaq) # For plan introspection
+        #bps.configure(daq, events=ndaq) # For plan introspection
 
         # Add sequencer, DAQ to detectors for scan
         dets = [daq, seq]
@@ -275,13 +280,157 @@ class User():
                motor, start, end,
                npoints)
 
-        final_plan = bpp.finalize_wrapper(scan_plan, self._cleanup_plan())
+        final_plan = bpp.finalize_wrapper(scan_plan, self.__cleanup_plan())
 
         return final_plan 
 
 
+    def lamo_grid_scan(self, x_start, x_end, xsteps,
+                       y_start, y_end, ysteps, 
+                       angle, ndaq, record=True):
+        """Return a laminography grid scan plan. 
+
+        Usage
+        -----
+        p = x.lamo_grid_scan(x_start, x_end, xsteps, y_start, y_end, ysteps,
+                        angle, ndaq, record=True)
+        RE(p)
+
+        Parameters
+        ----------
+
+        x_start : float
+            Starting position of the target x stage (in mm).
+
+        x_end : float
+            Ending position of the target x stage (in mm).
+
+        xsteps : int
+            Number of steps to divide the x distance into.
+
+        y_start : float
+            Starting position of the target y stage (in mm).
+
+        y_end : float
+            Ending position of the target y stage (in mm).
+
+        ysteps : int
+            Number of steps to divide the y distance into.
+
+        angle : float
+            The angle of the laminography stage holder.
+
+        ndaq : int
+            Number of points to record for each laminography position.
+
+        record: bool
+            Whether or not to record in the DAQ. Defaults to True.
+
+        Examples
+        --------
+
+        # Record 1000 points per scan 
+        x.lamo_grid_scan(14.853, 14.903, 10, 6.690, 6.740, 10,
+                        45, ndaq=1000, record=True)
+
+        # Record a different number of data points per laminography position
+        x.lamo_grid_scan(14.853, 14.903, 10, 6.690, 6.740, 10,
+                        45, ndaq=1500, record=True)
+
+        # Don't record
+        x.lamo_grid_scan(14.853, 14.903, 10, 6.690, 6.740, 10,
+                        45, ndaq=1500, record=False)
+        """
+
+        grid_plan = self.__grid_scan(tgx, x_start, x_end, xsteps,
+                                    tgy, y_start, y_end, ysteps,
+                                    tgz, angle, ndaq, record)
+
+        final_plan = bpp.finalize_wrapper(grid_plan, self.__cleanup_plan())
+
+        return final_plan 
+
+
+    def __grid_scan(self, x_motor, x_start, x_end, xsteps,
+                    y_motor, y_start, y_end, ysteps,
+                    z_motor, angle, ndaq, record=True):
+        logging.debug("Setting up the sequencer for %s daq points", ndaq)
+        self.__setup_sequencer(ndaq)
+
+        # Setup the pulse picker
+        if pp.mode.get() == 3:
+            logging.debug("The pulse picker is already in burst mode")
+        else:    
+            logging.debug("Setting up the pulse picker for burst mode")
+            pp.burst(wait=True)
+
+        # Setup the DAQ
+        daq.record = record
+        daq.configure(events=ndaq)
+        #bps.configure(daq, events=ndaq) # For plan introspection
+
+        # Add sequencer, DAQ to detectors for scan
+        dets = [daq, seq]
+
+        # Log stuff
+        logging.debug("Returning __grid_scan with the following parameters:")
+        logging.debug("x_start: {}".format(x_start))
+        logging.debug("x_end: {}".format(x_end))
+        logging.debug("xsteps: {}".format(xsteps))
+        logging.debug("y_start: {}".format(y_start))
+        logging.debug("y_end: {}".format(y_end))
+        logging.debug("y_steps: {}".format(ysteps))
+        logging.debug("angle: {}".format(angle))
+        logging.debug("ndaq: {}".format(ndaq))
+        logging.debug("record: {}".format(record))
+        logging.debug("detectors: {}".format(dets))
+
+        z_start = z_motor.wm()
+
+        x_step_size = (x_end-x_start)/(xsteps-1)
+        logging.debug("X step size: {}".format(x_step_size))
+        y_step_size = (y_end-y_start)/(ysteps-1)
+        logging.debug("Y step size: {}".format(y_step_size))
+        z_step = self.__comp_z(y_step_size, angle)
+        logging.debug("Z step size: {}".format(z_step))
+        for i in range(ysteps):
+            new_y = y_start+y_step_size*i
+            logging.debug("Moving Y to {}".format(new_y))
+            yield from bps.mv(y_motor, new_y)
+            if i != 0: # Skip first step; assume focus is fine there
+                logging.debug("Moving Z by {}".format(z_step))
+                yield from bps.mvr(z_motor, z_step)
+            #for j in range(xsteps):
+            #    new_x = x_start+x_step_size*j
+            #    logging.debug("Moving X to {}".format(new_x))
+            #    yield from bps.mv(x_motor, new_x)
+            #    yield from count(dets, num=1)
+            #    # Give picker time to recover after scan
+            #    yield from bps.sleep(0.2)
+            yield from scan(dets, x_motor, x_start, x_end, xsteps) 
+
+        # Return to original positions
+        yield from bps.mv(x_motor, x_start)
+        yield from bps.mv(y_motor, y_start)
+        yield from bps.mv(z_motor, z_start)
+
+
+    def __comp_z(self, delta_y, angle):
+        """Calculate the amount to compensate in Z direction for motion in the
+        Y-axis during a grid scan."""
+        comp = delta_y * np.tan(np.pi * angle / 180.)
+
+        return comp
+
+
     def __setup_sequencer(self, num_points):
         # Do smart stuff with the sequencer now
+
+        # Setup dummy sequence (stupid hack for weird sequencer behavior)
+        dummy_sequence = [[0,0,0,0] for i in range(10)]
+        d_sequence = [ arr for arr in zip(*dummy_sequence) ]
+        seq.sequence.put_seq(d_sequence)
+        time.sleep(2)
 
         # PP Open line
         pp_open = [[168, 0, 0, 0]] # Open pulse picker, no delay
@@ -298,14 +447,17 @@ class User():
         # Add last DAQ event
         last_daq = [[169, 1, 0, 0]] 
 
-        s = pp_open + pi_line + daq_lines + pp_close + last_daq
+        # Add wait time for picker
+        #seq_wait = [[0, 60, 0, 0]]
+ 
+        s = pp_open + pi_line + daq_lines + pp_close + last_daq #+ seq_wait
 
         sequence = [ arr for arr in zip(*s) ]
 
         seq.sequence.put_seq(sequence)
 
 
-    def _cleanup_plan(self):
+    def __cleanup_plan(self):
         # Plan to do some cleanup at the end of a scan
         yield from bps.abs_set(pp.cmd_reset, 1) # Reset pulse picker
         yield from bps.abs_set(pp.cmd_close, 1) # Close pulse picker

--- a/mec/beamline.py
+++ b/mec/beamline.py
@@ -32,17 +32,30 @@ with safe_load('target x'):
     target_x = epics_motor.IMS('MEC:USR:MMS:17', name='target x')
 
 
-with safe_load('target hexapod'):
-    from .devices import PI_M824_Hexapod 
-    tc_hexapod = PI_M824_Hexapod('MEC:HEX:01', name='target hexapod') 
+#with safe_load('target hexapod'):
+#    from .devices import PI_M824_Hexapod 
+#    tc_hexapod = PI_M824_Hexapod('MEC:HEX:01', name='target hexapod') 
+#
+#    from .devices import TargetStage
+#    target = TargetStage(target_x, tc_hexapod, 0.75, 0.75)
 
-    from .devices import TargetStage
-    target = TargetStage(target_x, tc_hexapod, 0.75, 0.75)
+with safe_load('target xy stage'):
+    from .devices import TargetXYStage
+    from pcdsdevices import epics_motor 
+    target_y = epics_motor.Newport('MEC:PPL:MMN:09', name='target y')
+    tgt = TargetXYStage(target_x, target_y, 3.7, 3.5)
 
+#with safe_load('event sequencer'):
+#    from pcdsdevices.sequencer import EventSequencer
+#    seq = EventSequencer('ECS:SYS0:6', name='seq_6')
 
 with safe_load('event sequencer'):
     from pcdsdevices.sequencer import EventSequencer
-    seq = EventSequencer('ECS:SYS0:6', name='seq_6')
+    seq = EventSequencer('FAKE:ECS:SYS0:6', name='seq_6')
+
+#with safe_load('fake event sequencer'):
+#    from pcdsdevices.sequencer import EventSequencer
+#    fake_seq = EventSequencer('FAKE:ECS:SYS0:6', name='fake_seq_6')
 
 #with safe_load('event sequence'):
 #    from pcdsdevices.sequencer import EventSequence
@@ -83,7 +96,6 @@ with safe_load('YAG screens'): # Also known as PIMs
         time.sleep(0.1)
         mec_yag3.insert()
 
-        
 with safe_load('IPMs'):
     from pcdsdevices.ipm import IPM
     mec_ipm1 = IPM('MEC:HXM:IPM:01', name='mec ipm1')
@@ -91,6 +103,80 @@ with safe_load('IPMs'):
     mec_ipm3 = IPM('MEC:XT2:IPM:03', name='mec ipm3')
 
 with safe_load('Highland'):
-    from .laser import Highland
+    from .laser_devices import Highland
     nsl_highland = Highland('MEC:LPL:AMD:01', name='mec highland')
 
+with safe_load('Attenuator'):
+    from pcdsdevices.attenuator import Attenuator
+    att = Attenuator('IOC:MEC:ATT', 10, name='mec attenuator')
+
+with safe_load('long pulse waveplates'):
+    from pcdsdevices import epics_motor
+    wp_ab = epics_motor.IMS('MEC:NS1:MMS:02', name='waveplate AB')
+    wp_ef = epics_motor.IMS('MEC:NS1:MMS:01', name='waveplate EF')
+    wp_gh = epics_motor.Newport('MEC:LAS:MMN:30', name='waveplate GH')
+    wp_ij = epics_motor.Newport('MEC:LAS:MMN:29', name='waveplate IJ')
+
+with safe_load('testmotors'):
+    from pcdsdevices import epics_motor 
+    test_1 = epics_motor.Newport('MEC:PPL:MMN:23', name='test 1')
+    test_2 = epics_motor.Newport('MEC:PPL:MMN:24', name='test 2')
+
+with safe_load('daq'):
+    from pcdsdaq.daq import Daq
+    from mec.db import RE
+    daq = Daq(RE=RE)
+#with safe_load('Nanosecond laser'):
+#    from .laser import NanoSecondLaser
+#    nsl = NanoSecondLaser()
+
+with safe_load('SPL Modes'):
+    from .spl_modes import DG645
+    from .spl_modes import UniblitzEVRCH
+
+    las_dg = DG645('MEC:LAS:DDG:08', name='uniblitz dg')
+    las_evr = UniblitzEVRCH('LAS:MEC:EVR:03:TRIG2', name='uniblitz las evr')
+    uni_evr = UniblitzEVRCH('EVR:MEC:USR01:TRIG5', name='uniblitz usr evr')
+
+    wt = 0.5 # sleep time between commands
+
+    def spl_align():
+        print("Disabling Slicer...")
+        las_evr.ch_enable.put(0) # Disable
+        time.sleep(wt)
+        print("Disabling Shutters...")
+        uni_evr.ch_enable.put(0) # Disable
+        time.sleep(wt)
+        print("Opening Shutters...")
+        las_dg.ch_AB_pol.put(0)  # Negative
+        las_dg.ch_CD_pol.put(0)  # Negative
+        time.sleep(wt)
+        print("Setting laser to 5 Hz...")
+        las_evr.ch_eventc.put(44)
+        time.sleep(wt)
+        print("Laser is in alignment mode.")
+        print("Remember to change to target mode after alignment.")
+
+    def spl_target():
+        print("Setting laser to single shot...")
+        las_evr.ch_eventc.put(176)
+        time.sleep(wt)
+        print("Disabling Slicer...")
+        las_evr.ch_enable.put(0) # Disable
+        time.sleep(wt)
+        print("Enabling Shutters...")
+        uni_evr.ch_enable.put(1) # Enable
+        time.sleep(wt)
+        print("Closing Shutters...")
+        las_dg.ch_AB_pol.put(1)  # Positive
+        las_dg.ch_CD_pol.put(1)  # Positive
+        time.sleep(wt)
+        print("Enabling Slicer...")
+        las_evr.ch_enable.put(1) # Enable
+        time.sleep(wt)
+        print("Setting up Event Sequencer...")
+        s = [[177,0,0,0], [176,24,0,0]]
+        seq.sequence.put_seq(s)
+        print("Laser is in target mode. Single shot only!!!.")
+        print("Don't forget to use the --prelasertrig 24 option in the script!!")
+        print("Remember to change to alignment mode before aligning.")

--- a/mec/laser.py
+++ b/mec/laser.py
@@ -1,0 +1,778 @@
+#!/usr/bin/env python
+#
+# Module for the MEC laser systems.
+#
+
+import logging
+import time
+import logging
+from bluesky.plans import count
+import bluesky.plan_stubs as bps
+import bluesky.preprocessors as bpp
+from mec.db import seq, daq
+from mec.db import shutter1, shutter2, shutter3, shutter4, shutter5, shutter6
+from mec.db import mec_pulsepicker as pp
+from .sequence import Sequence
+
+logger = logging.getLogger(__name__)
+
+class Laser():
+    """Base class for the MEC laser systems."""
+    def __init__(self, Laser, Rate=5, PreDark=0, PreX=0, PreO=0, PostDark=0, PostX=0, 
+                 PostO=0, During=1, PreLaserTrig=0, SlowCam=False,
+                 SlowCamDelay=5, Shutters=[1,2,3,4,5,6]):
+
+        self._config = {'laser': Laser,
+                        'rate': int(Rate),
+                        'predark': int(PreDark),
+                        'prex': int(PreX),
+                        'preo': int(PreO),
+                        'postdark': int(PostDark),
+                        'postx': int(PostX),
+                        'posto': int(PostO),
+                        'during': int(During),
+                        'prelasertrig': int(PreLaserTrig),
+                        'slowcam': SlowCam,
+                        'slowcamdelay': int(SlowCamDelay),
+                        'shutters': Shutters}
+        
+        self._seq = Sequence()
+        self._shutters = {1: shutter1, 
+                          2: shutter2,
+                          3: shutter3,
+                          4: shutter4,
+                          5: shutter5,
+                          6: shutter6}
+
+        self._sync_markers = {0.5:0, 1:1, 5:2, 10:3, 30:4, 60:5, 120:6, 360:7}
+
+    @property
+    def config(self):
+        """Return the current configuration of the laser."""
+        conf = self._config.copy()
+
+        return conf
+
+    @property
+    def __laser(self):
+        """The laser to run (short pulse or long pulse). SHOULD NOT BE 
+        CONFIGURED EXCEPT AT INIT. DON'T TOUCH THIS UNLESS YOU KNOW WHAT YOU'RE
+        DOING."""
+        return self._config['laser']
+
+    @__laser.setter
+    def __laser(self, value):
+        self._config['laser'] = value
+
+    @property
+    def __rate(self):
+        """The operation rate of the laser. Used to configure the event 
+        sequencer sync marker. SHOULD NOT BE CONFIGURED EXCEPT AT INIT.
+        DON'T TOUCH THIS UNLESS YOU KNOW WHAT YOU'RE DOING."""
+        return self._config['rate']
+
+    @__rate.setter
+    def __rate(self, value):
+        self._config['rate'] = value
+    
+    @property
+    def predark(self):
+        """The number of pre-dark shots to take for a given sequence."""
+        return int(self._config['predark'])
+
+    @predark.setter
+    def predark(self, value):
+        self._config['predark'] = int(value)
+
+    @property
+    def prex(self):
+        """The number of pre-xray shots to take for a given sequence."""
+        return int(self._config['prex'])
+
+    @prex.setter
+    def prex(self, value):
+        self._config['prex'] = int(value)
+
+    @property
+    def preo(self):
+        """The number of pre-optical shots to take for a given sequence."""
+        return int(self._config['preo'])
+
+    @preo.setter
+    def preo(self, value):
+        self._config['preo'] = int(value)
+
+    @property
+    def postdark(self):
+        """The number of post-dark shots to take for a given sequence."""
+        return int(self._config['postdark'])
+
+    @postdark.setter
+    def postdark(self, value):
+        self._config['postdark'] = int(value)
+
+    @property
+    def postx(self):
+        """The number of post-xray shots to take for a given sequence."""
+        return int(self._config['postx'])
+
+    @postx.setter
+    def postx(self, value):
+        self._config['postx'] = int(value)
+
+    @property
+    def posto(self):
+        """The number of post-optical shots to take for a given sequence."""
+        return int(self._config['posto'])
+
+    @posto.setter
+    def posto(self, value):
+        self._config['posto'] = int(value)
+
+    @property
+    def during(self):
+        """The number of 'during' (optical + x-ray)  shots to take for a given 
+        sequence."""
+        return int(self._config['during'])
+
+    @during.setter
+    def during(self, value):
+        self._config['during'] = int(value)
+
+    @property
+    def prelasertrig(self):
+        """The number (N) of N x 8.4 ms multiples to wait before the optical
+        laser shot. Used to trigger slow diagnostics, shutters, etc. Default
+        is 0."""
+        return int(self._config['prelasertrig'])
+
+    @prelasertrig.setter
+    def prelasertrig(self, value):
+        self._config['prelasertrig'] = int(value)
+
+    @property
+    def slowcam(self):
+        """Option to add in the PI-MTE, Pixis 'slow' cameras devices to the
+        optical sequence. Default is False."""
+        return self._config['slowcam']
+
+    @slowcam.setter
+    def slowcam(self, value):
+        self._config['slowcam'] = bool(value)
+
+    @property
+    def slowcamdelay(self):
+        """The integer number of beam codes to delay the sequence to allow the
+        slow cameras to open their shutters. Default is 5; this should not
+        usually be changed."""
+        return self._config['slowcamdelay']
+
+    @slowcamdelay.setter
+    def slowcamdelay(self, value):
+        self._config['slowcamdelay'] = int(value)
+
+    @property
+    def shutters(self):
+        """The MEC target chamber shutters to close on shot. Default is all of
+        them (1 through 6). Configure this setting by providing a list of
+        shutters to close prior to the shot, e.g. laser.shutters = [1,2,4,6]"""
+        return self._config['shutters']
+
+    @shutters.setter
+    def shutters(self, value):
+        allowed = [1,2,3,4,5,6]
+        new_shutters = []
+        for v in value:
+            if v in allowed:
+                new_shutters.append(int(v))
+            else:
+                print("Unrecognized shutter {}. Skipping...".format(v))
+        self._config['shutters'] = new_shutters
+
+    def configure(self, conf):
+        """Configure the laser for the given parameters.
+
+        Laser(conf)
+
+        Parameters
+        ----------
+        conf : dict
+            A dictionary containing the configuration of the laser. This
+            dictionary takes the following form:
+                conf = {'laser': <laser>,
+                        'rate': <rate>,
+                        'predark': <predark>,
+                        'prex': <prex>,
+                        'preo': <preo>,
+                        'postdark': <postdark>,
+                        'postx': <postx>,
+                        'posto': <posto>,
+                        'during': <during>,
+                        'prelasertrig': <prelasertrig>,
+                        'slowcam': <slowcam>,
+                        'slowcamdelay': <slowcamdelay>,
+                        'shutters'= <shutters>}
+
+                Default configuration:
+                    Rate=5,
+                    PreDark=0,
+                    PreX=0,
+                    PreO=0,
+                    PostDark=0,
+                    PostX=0, 
+                    PostO=0,
+                    During=1,
+                    PreLaserTrig=0,
+                    SlowCam=False,
+                    SlowCamDelay=5,
+                    Shutters=[1,2,3,4,5,6]
+
+            This method can be given a subset of these parameters. The method
+            will only apply recognized parameters that are supplied, and will
+            use the current values for parameters that are not supplied.
+ 
+            Configuration Definitions
+            ------------------------- 
+            Laser : string
+                The laser that you want to shoot. There are two options:
+                'shortpulse', and 'longpulse'. THIS SHOULD NOT BE CONFIGURED
+                EXCEPT AT INIT.
+
+            Rate : int
+                Integer rate at which you want to take laser shots, with or
+                without x-rays, synchronized to the XFEL. THIS SHOULD NOT BE 
+                CONFIGURED EXCEPT AT INIT.
+
+            PreDark : int
+                Record dark shots (no XFEL, no optical laser) prior to the
+                X-ray + optical laser shot.
+
+            PreX : int
+                Record dark X-ray only shots (no optical laser) prior to the
+                X-ray + optical laser shot.
+
+            PreO : int
+                Record optical only laser shots (no XFEL) prior to the X-ray +
+                optical laser shot.
+
+            PostDark : int
+                Record dark shots (no XFEL, no optical laser) after the X-ray +
+                optical laser shot.
+
+            PostX : int
+                Record dark X-ray only shots (no optical laser) after the X-ray 
+                + optical laser shot.
+
+            PostO : int
+                Record optical only laser shots (no XFEL) after the X-ray +
+                optical laser shot.
+
+            During : int
+                Record optical laser + X-ray laser shots. 
+
+            PreLaserTrig : int
+                Add a pre-laser trigger to the  sequence that occurs
+                approximately N x 8.4 ms before the laser shot. Used to trigger
+                slow diagnostics, shutters, etc.
+
+            SlowCam : bool
+                Add the slow cameras (i.e. PI-MTEs, Pixis) to the sequence.
+
+            SlowCamDelay : int
+                The number of beam codes to delay the sequence to allow the slow
+                cameras to open their shutters.
+    
+            Shutters : list
+                The shutters that must be closed prior to taking the laser shot.
+                This is used to protect cameras and other diagnostics from the
+                shot. Defaults to all shutters ([1,2,3,4,5,6]).        
+        """
+
+        for key in conf.keys():
+            if key in self._config.keys():
+                if key in ['laser', 'rate']:
+                    # Not allowed to configure these except at init. Skip.
+                    pass
+                else:
+                    self._config[key] = conf[key]
+            else:
+                print("Unrecognized key: {}. Skipping ... ".format(key))
+
+        seq_conf = {'rate': self._config['rate'],
+                    'prelasertrig': self._config['prelasertrig'],
+                    'slowcam': self._config['slowcam'],
+                    'slowcamdelay': self._config['slowcamdelay']}
+
+        self._seq.configure(Rate=seq_conf['rate'], 
+                            PreLaserTrig=seq_conf['prelasertrig'],
+                            SlowCam=seq_conf['slowcam'],
+                            SlowCamDelay=seq_conf['slowcamdelay'])
+
+    def _single_shot_plan(self, record=True, use_l3t=False, controls=[],
+                           end_run=True):
+        """Definition of plan for taking laser shots with the MEC laser."""
+        # TODO: Setup slowcam
+        # TODO: Add attenuator control
+
+        logging.debug("Generating shot plan using _shot_plan.")
+        logging.debug("_shot_plan config:")
+        logging.debug("{}".format(self._config))
+        logging.debug("Record: {}".format(record))
+        logging.debug("use_l3t: {}".format(use_l3t))
+        logging.debug("controls: {}".format(controls))
+
+        # Make sure that any updates to configuration are applied
+        self.configure(self._config)
+
+        # Check number of shots for long pulse laser
+        if self._config['laser'] == 'longpulse':
+            lpl_shots = self._config['preo'] + self._config['during'] + \
+                        self._config['posto']
+
+            if lpl_shots > 1:
+                m = ("Cannot shoot the long pulse laser more than once in a "
+                     "sequence! Please reduce the number of optical shots "
+                     "requested to 1!")
+                raise Exception(m)
+
+        # Setup the daq based on config
+        total_shots = self._config['predark'] + self._config['prex'] + \
+                      self._config['preo'] + self._config['postdark'] + \
+                      self._config['postx'] + self._config['posto'] + \
+                      self._config['during']
+
+        print("Configured for {} total shots.".format(total_shots))
+        logging.debug("Total shots: {}".format(total_shots))
+    
+        yield from bps.configure(daq, begin_sleep=2, record=record, use_l3t=use_l3t, controls=controls)
+
+        # Add sequencer, DAQ to detectors for shots
+        dets = [daq, seq]
+
+        for det in dets:
+            yield from bps.stage(det)
+
+        # Setup the pulse picker for single shots in flip flop mode
+        #pp.flipflop(wait=True)
+
+        # Setup sequencer for requested rate
+        sync_mark = int(self._sync_markers[self._config['rate']])
+        seq.sync_marker.put(sync_mark)
+        seq.play_mode.put(0) # Run sequence once
+
+        # Dark (no optical laser, no XFEL) shots
+        if self._config['predark'] > 0:
+            # Get number of predark shots
+            shots = self._config['predark']
+            logging.debug("Configuring for {} predark shots".format(shots))
+            yield from bps.configure(daq, events=shots)
+
+            # Preshot dark, so use preshot laser marker
+            pre_dark_seq = self._seq.darkSequence(shots, preshot=True)
+            seq.sequence.put_seq(pre_dark_seq)
+
+            # Number of shots is determined by sequencer, so just trigger/read
+            print("Taking {} predark shots ... ".format(self._config['predark']))
+            yield from bps.trigger_and_read(dets)
+
+        # Pre-xray (no optical laser, XFEL only) shots
+        if self._config['prex'] > 0:
+            # Get number of prex shots
+            shots = self._config['prex']
+            logging.debug("Configuring for {} prex shots".format(shots))
+            yield from bps.configure(daq, events=shots)
+
+            # Preshot x-ray only shots, so use preshot laser marker
+            prex_seq = self._seq.darkXraySequence(shots, preshot=True)
+            seq.sequence.put_seq(prex_seq)
+
+            # Number of shots is determined by sequencer, so just trigger/read
+            print("Taking {} prex shots ... ".format(shots))
+            yield from bps.trigger_and_read(dets)
+            
+        # Pre-optical (optical laser only, no XFEL) shots
+        if self._config['preo'] > 0:
+            # Get number of preo shots
+            shots = self._config['preo']
+            logging.debug("Configuring for {} preo shots".format(shots))
+            yield from bps.configure(daq, events=shots)
+
+            # Optical only shot, with defined laser
+            preo_seq = self._seq.opticalSequence(shots, self._config['laser'],\
+                                                 preshot=True)
+            seq.sequence.put_seq(preo_seq)
+
+            # Number of shots is determined by sequencer, so just take 1 count
+            print("Taking {} preo shots ... ".format(shots))
+            yield from bps.trigger_and_read(dets)
+
+        # 'During' (optical laser + XFEL) shots
+        if self._config['during'] > 0:
+            # Get number of during shots
+            shots = self._config['during']
+            logging.debug("Configuring for {} during shots".format(shots))
+            yield from bps.configure(daq, events=shots)
+
+            # During shot, with defined laser
+            during_seq = self._seq.duringSequence(shots, self._config['laser'])
+            seq.sequence.put_seq(during_seq)
+
+            # Number of shots is determined by sequencer, so just take 1 count
+            print("Taking {} during shots ... ".format(shots))
+            yield from bps.trigger_and_read(dets)
+
+        # Post-optical (optical laser only, no XFEL) shots
+        if self._config['posto'] > 0:
+            # Get number of post optical shots
+            shots = self._config['posto']
+            logging.debug("Configuring for {} posto shots".format(shots))
+            yield from bps.configure(daq, events=shots)
+
+            # Optical only shot, with defined laser
+            posto_seq = self._seq.opticalSequence(shots, self._config['laser'],\
+                                                  preshot=False)
+            seq.sequence.put_seq(posto_seq)
+
+            # Number of shots is determined by sequencer, so just take 1 count
+            print("Taking {} posto shots ... ".format(shots))
+            yield from bps.trigger_and_read(dets)
+
+        # Post-xray (no optical laser, XFEL only) shots
+        if self._config['postx'] > 0:
+            # Get number of postx shots
+            shots = self._config['postx']
+            logging.debug("Configuring for {} postx shots".format(shots))
+            yield from bps.configure(daq, events=shots)
+
+            # Postshot x-ray only shots, so use postshot laser marker
+            postx_seq = self._seq.darkXraySequence(shots, preshot=False)
+            seq.sequence.put_seq(postx_seq)
+
+            # Number of shots is determined by sequencer, so just take 1 count
+            print("Taking {} postx shots ... ".format(shots))
+            yield from bps.trigger_and_read(dets)
+            
+        # Dark (no optical laser, no XFEL) shots
+        if self._config['postdark'] > 0:
+            # Get number of postdark shots
+            shots = self._config['postdark']
+            logging.debug("Configuring for {} postdark shots".format(shots))
+            yield from bps.configure(daq, events=shots)
+
+            # Postshot dark, so use postshot laser marker
+            post_dark_seq = self._seq.darkSequence(shots, preshot=False)
+            seq.sequence.put_seq(post_dark_seq)
+
+            # Number of shots is determined by sequencer, so just take 1 count
+            print("Taking {} postdark shots ... ".format(shots))
+            yield from bps.trigger_and_read(dets)
+
+        
+        for det in dets:
+            yield from bps.unstage(det)
+
+        if end_run:
+            daq.end_run()
+
+    def shot(self, record=True, use_l3t=False, controls=[], end_run=True):
+        """Return a plan for executing a laser shot (or shots), based on the 
+        current configuration of the laser. To modify the shot, update the
+        laser configuration, then call this method. This method uses the pulse
+        picker and sequencer to take XFEL + Optical laser shots. Multiple XFEL
+        and/or laser shots will be performed by setting up the sequencer for
+        a multiple shots, and running the sequence once.
+
+        laser.shot(record=True)
+
+        Parameters
+        ----------
+        record : bool
+            Select whether the run will be recorded or not. Defaults to True.
+
+        use_l3t : bool
+            Select whether the run will use a level 3 trigger or not. Defaults
+            to False.
+
+        controls : list
+            List of controls devices to include values into the DAQ data stream
+            as variables. All devices must have a name attribute. Defaults to
+            empty list.
+
+        end_run : bool
+            Select whether or not to end the run after the shot. Defaults to
+            True.
+
+        Examples
+        --------
+        # Take a shot immediately, don't record
+
+        RE(laser.shot(record=False))
+
+        # Take a shot immediately, record
+
+        RE(laser.shot(record=True))
+
+        # Initialize the shot, record a shot at some later time when RE(p) is
+        # called. 
+
+        p = laser.shot(record=True)
+        ...
+        RE(p)
+        """
+
+        dev = []
+        for shutter in self._config['shutters']:
+            dev.append(self._shutters[shutter])
+
+        @bpp.stage_decorator(dev)
+        @bpp.run_decorator()
+        def inner(record, use_l3t, controls, end_run):
+            plan = self._single_shot_plan(record, use_l3t, controls, end_run)
+
+            return plan
+
+        return inner(record, use_l3t, controls, end_run)
+
+class NanoSecondLaser(Laser):
+    """Class for the MEC nanosecond laser."""
+    def __init__(self):
+        laser = 'longpulse'
+        super().__init__(laser, Rate=10)
+
+    def __charge(self):
+        """Charge the PFN racks for longpulse laser."""
+        #TODO
+        raise NotImplementedError("This method is not implemented yet!")
+
+class FemtoSecondLaser(Laser):
+    """Class for the MEC femtosecond laser."""
+    def __init__(self, *args, **kwargs):
+        laser = 'shortpulse'
+        super().__init__(laser, *args, Rate=5, **kwargs)
+
+    def _grid_scan_plan(self, motor1, m1_start, m1_end, m1_steps,
+                               motor2, m2_start, m2_end, m2_steps,
+                               record=True, use_l3t=False, controls=[],
+                               end_run=True, carriage_return=True):
+        # Log stuff
+        logging.debug("Returning _grid_scan with the following parameters:")
+        logging.debug("m1_start: {}".format(m1_start))
+        logging.debug("m1_end: {}".format(m1_end))
+        logging.debug("m2_steps: {}".format(m1_steps))
+        logging.debug("m2_start: {}".format(m2_start))
+        logging.debug("m2_end: {}".format(m2_end))
+        logging.debug("m2_steps: {}".format(m2_steps))
+        logging.debug("end_run: {}".format(end_run))
+        logging.debug("carriage_return: {}".format(carriage_return))
+
+        m1_step_size = (m1_end-m1_start)/(m1_steps-1)
+        logging.debug("m1 step size: {}".format(m1_step_size))
+        m2_step_size = (m2_end-m2_start)/(m2_steps-1)
+        logging.debug("m2 step size: {}".format(m2_step_size))
+        for i in range(m2_steps):
+            new_m2 = m2_start+m2_step_size*i
+            logging.debug("Moving motor2 to {}".format(new_m2))
+            yield from bps.mv(motor2, new_m2)
+            for j in range(m1_steps):
+                new_m1 = m1_start+m1_step_size*j
+                logging.debug("Moving motor1 to {}".format(new_m1))
+                yield from bps.mv(motor1, new_m1)
+                logging.debug("Calling self._single_shot_plan...")
+                yield from self._single_shot_plan(record, use_l3t, controls,
+                                                   False)
+                # If this is the last move in the scan, check cleanup settings
+                if (i == (m1_steps-1)) and (j == (m2_steps -1)):
+                    if carriage_return: # Then go back to start
+                        yield from bps.mv(motor1, m1_start)
+                        yield from bps.mv(motor2, m2_start)
+                    if end_run:
+                        daq.end_run()
+
+    def grid_scan_shot(self, motor1, m1_start, m1_end, m1_steps,
+                       motor2, m2_start, m2_end, m2_steps,
+                       record=True, use_l3t=False, controls=[], end_run=True,
+                       carriage_return=True):
+        """Return a plan for scanning a motor, taking a shot at each point."""
+
+        dev = []
+        for shutter in self._config['shutters']:
+            dev.append(self._shutters[shutter])
+
+        @bpp.stage_decorator(dev)
+        @bpp.run_decorator()
+        def inner(motor1, m1_start, m1_end, m1_steps,
+                  motor2, m2_start, m2_end, m2_steps,
+                  record, use_l3t, controls, end_run, carriage_return):
+            plan = self._grid_scan_plan(motor1, m1_start, m1_end, m1_steps,
+                                         motor2, m2_start, m2_end, m2_steps,
+                                         record, use_l3t, controls, end_run,
+                                         carriage_return)
+
+            return plan
+
+        return inner(motor1, m1_start, m1_end, m1_steps,
+                     motor2, m2_start, m2_end, m2_steps,
+                     record, use_l3t, controls, end_run, carriage_return)
+
+    def _1D_fly_scan(self, motor, start, end, record, use_l3t, controls,
+                     end_run, carriage_return, predelay, postdelay):
+                      
+        """Plan for setting up a one-dimensional fly scan."""
+
+        logging.debug("Generating 1D fly scan shot plan using _1D_fly_scan.")
+        logging.debug("_shot_plan config:")
+        logging.debug("{}".format(self._config))
+        logging.debug("motor: {}".format(motor))
+        logging.debug("start: {}".format(start))
+        logging.debug("end: {}".format(end))
+        logging.debug("predelay: {}".format(predelay))
+        logging.debug("postdelay: {}".format(postdelay))
+        logging.debug("Record: {}".format(record))
+        logging.debug("use_l3t: {}".format(use_l3t))
+        logging.debug("controls: {}".format(controls))
+        logging.debug("carriage_return: {}".format(carriage_return))
+        logging.debug("end_run: {}".format(end_run))
+
+        # Adjust start/end for any pre/post-delays
+        if bool(predelay):
+            if (end-start) >= 0:
+                start -= predelay
+            else:
+                start += predelay
+
+        if bool(postdelay):
+            if (end-start) >= 0:
+                end += postdelay
+            else:
+                end -= postdelay
+
+        m_velo = motor.velocity.get()
+        # Total number of events: (mm/(mm/s))*(events/s) = events
+        nevents = int((abs(end-start)/m_velo)*self.config['rate'])
+
+        shot_type_count = 0
+        shot_types = ['predark', 'prex', 'preo', 'postdark', 'postx', 'posto',
+                      'during']
+
+        # Look for more than one shot type (should only set up sequencer for
+        # one shot type at a time in this operation mode).
+        old_config = self.config
+        new_config = self.config
+        for shot_type in shot_types:
+            if bool(self.config[shot_type]):
+                shot_type_count += 1
+                if shot_type_count >= 2:
+                    self.configure(old_config)
+                    raise ValueError("Cannot have more than one type of shot "
+                                     "for a given 1D scan! Please change the "
+                                     "laser configuration to have only one "
+                                     "shot type!")
+                new_config[shot_type] = nevents
+
+        if shot_type_count == 1:
+            # Found only one shot type; valid shot
+            self.configure(new_config)
+        else:
+            # Something is weird
+            raise Exception("Please configure the laser for one shot type! "
+                            "The configuration is invalid!")
+        
+        # Get into initial position
+        yield from bps.mv(motor, start)
+
+        #yield from bps.mv(motor, end) # Can't do this since bps.mv waits
+                                       # for completion. :(
+                                       # Make update to bps.mv?
+        motor.mv(end)
+        # Shoot stuff
+        yield from self._single_shot_plan(record=record, use_l3t=use_l3t,
+                                          controls=controls, end_run=end_run)
+
+        if carriage_return:
+            yield from bps.mv(motor, start)
+        if end_run:
+            daq.end_run()
+
+    def fly_scan_1D_shot(self, motor, start, end, record=True, use_l3t=False,
+                         controls=[], end_run=True, carriage_return=True,
+                         predelay=None, postdelay=None):
+        """Return a plan for doing a 1D fly scan with the laser, continuously
+        taking shots along the way."""
+        dev = []
+        for shutter in self._config['shutters']:
+            dev.append(self._shutters[shutter])
+
+        @bpp.stage_decorator(dev)
+        @bpp.run_decorator()
+        def inner(motor, start, end, record, use_l3t, controls, end_run,
+                  carriage_return, predelay, postdelay):
+
+            plan = self._1D_fly_scan(motor, start, end, record,
+                                     use_l3t, controls, end_run,
+                                     carriage_return, predelay, postdelay)
+
+            return plan
+
+        return inner(motor, start, end, record, use_l3t, controls, end_run,
+                     carriage_return, predelay, postdelay)
+
+    def _2D_fly_scan_plan(self, motor1, m1_start, m1_end, motor2, m2_start,
+                          m2_end, m2_steps, predelay, postdelay, record, 
+                          use_l3t, controls, end_run, carriage_return):
+        # Log stuff
+        logging.debug("Returning _2D_fly_scan with the following parameters:")
+        logging.debug("m1_start: {}".format(m1_start))
+        logging.debug("m1_end: {}".format(m1_end))
+        logging.debug("m2_start: {}".format(m2_start))
+        logging.debug("m2_end: {}".format(m2_end))
+        logging.debug("m2_steps: {}".format(m2_steps))
+        logging.debug("end_run: {}".format(end_run))
+        logging.debug("carriage_return: {}".format(carriage_return))
+
+        m2_step_size = (m2_end-m2_start)/(m2_steps-1)
+        logging.debug("m2 step size: {}".format(m2_step_size))
+        for i in range(m2_steps):
+            new_m2 = m2_start+m2_step_size*i
+            logging.debug("Moving motor2 to {}".format(new_m2))
+            yield from bps.mv(motor2, new_m2)
+            logging.debug("Calling self._1D_fly_scan...")
+            yield from self._1D_fly_scan(motor1, m1_start, m1_end, record, 
+                                         use_l3t, controls, False, 
+                                         carriage_return, predelay, postdelay)
+            #yield from self._single_shot_plan(record, use_l3t, controls,
+            #                                   False)
+            # Last move in the scan, so check cleanup settings
+            #if j == (m2_steps-1):
+        if carriage_return:
+            yield from bps.mv(motor1, m1_start)
+            yield from bps.mv(motor2, m2_start)
+        if end_run:
+            daq.end_run()
+
+    def fly_scan_2D_shot(self, motor1, m1_start, m1_end, motor2, m2_start,
+                         m2_end, m2_steps, predelay=None, postdelay=None,
+                         record=True, use_l3t=False, controls=[], end_run=True,
+                         carriage_return=True):
+        """Return a plan for doing a 2D fly scan with the laser, continuously
+        taking shots along the way."""
+        
+        dev = []
+        for shutter in self._config['shutters']:
+            dev.append(self._shutters[shutter])
+
+        @bpp.stage_decorator(dev)
+        @bpp.run_decorator()
+        def inner(motor1, m1_start, m1_end, motor2, m2_start, m2_end, m2_steps,
+                  predelay, postdelay, record, use_l3t, controls, end_run,
+                  carriage_return):
+
+            plan = self._2D_fly_scan_plan(motor1, m1_start, m1_end, motor2, 
+                                          m2_start, m2_end, m2_steps, predelay,
+                                          postdelay, record, use_l3t, controls,
+                                          end_run, carriage_return)
+
+            return plan
+
+        return inner(motor1, m1_start, m1_end, motor2, m2_start, m2_end, 
+                     m2_steps, predelay, postdelay, record, use_l3t, controls,
+                     end_run, carriage_return)

--- a/mec/laser_devices.py
+++ b/mec/laser_devices.py
@@ -1,0 +1,500 @@
+from ophyd import (Device, EpicsSignal, EpicsSignalRO, Component as C,
+                   FormattedComponent as FC)
+import time
+from mec.db import wp_ab, wp_ef, wp_gh, wp_ij
+
+class Highland(Device):
+    """Class for the MEC Highland pulse shaper."""
+
+    # Epics Signals
+    pulse_heights = C(EpicsSignal, ':PulseHeights')
+    pulse_heights_rbv = C(EpicsSignalRO, ':PulseHeights_RBV')
+    fiducial_delay_rbv = C(EpicsSignalRO, ':FiducialDelay_RBV')
+    fiducial_height_rbv = C(EpicsSignalRO, ':FiducialHeight_RBV')
+
+    def write_pulse(self, pulse):
+        """Write list of pulse heights to Highland."""
+        self.pulse_heights.put(pulse)
+
+    @property
+    def pulse_rbv(self):
+        """Returns list of current pulse heights."""
+        heights = self.pulse_heights_rbv.get()
+        return heights
+
+    @property
+    def fiducial_delay(self):
+        """Return current fiducial delay."""
+        delay = self.fiducial_delay_rbv.get()
+        return delay
+
+    @property
+    def fiducial_height(self):
+        """Return current fiducial height."""
+        height = self.fiducial_height_rbv.get()
+        return height
+
+class PolyScienceChiller(Device):
+    """Class for the MEC Polyscience chillers."""
+
+    # Epics Signals
+    presure_psi = C(EpicsSignalRO, ':PressurePSI')
+    presure_kpa = C(EpicsSignalRO, ':PressureKPA')
+    temp_setpoint = C(EpicsSignal, ':TempSetpoint')
+    temp_rbv = C(EpicsSignalRO, ':CurrentTemp')
+    on_off = C(EpicsSignal, ':TurnOnOff')
+    run_status = C(EpicsSignalRO, ':RunStatus')
+    fault_code = C(EpicsSignalRO, ':FaultStatusCode')
+    fault_status = C(EpicsSignalRO, ':FaultStatus')
+        
+    def set_temp(self, temp):
+        """Set temperature setpoint (in Celsius)."""
+        self.temp_setpoint.put(temp)
+
+    def turn_on(self):
+        """Turn on the chiller."""
+        self.on_off.put(1)
+
+    def turn_off(self):
+        """Turn off the chiller."""
+        self.on_off.put(0)
+
+    @property
+    def temp(self):
+        """Readback the current temperature (in Celsius)."""
+        curr_temp = self.temp_rbv.get()
+        return curr_temp
+
+    @property
+    def status(self):
+        """Readback the run status."""
+        stat = self.run_status.get()
+        return stat
+   
+    @property
+    def pressure_psi(self):
+        """Readback of the pressure in PSI."""
+        psi = self.pressure_psi.get()
+        return psi
+
+    @property
+    def pressure_kpa(self):
+        """Readback of the pressure in KPA."""
+        kpa = self.pressure_kpa.get()
+        return kpa
+
+    @property
+    def fault_status(self):
+        """Readback of the current fault status string."""
+        string = self.fault_status.get()
+        return string
+
+    @property
+    def fault_code(self):
+        """Readback of the current fault code."""
+        code = self.fault_code.get()
+        return code
+
+
+#class TDKLambda(Device):
+#    """Class for the MEC TDKLambda power supplies."""
+#
+#    # Epics signals
+#    enable = C(EpicsSignal, ':EnableOutput') 
+#    enable_rbv = C(EpicsSignalRO, ':EnableOutput_RBV')
+#    voltage_setpoint = C(EpicsSignal, ':VoltageSetPoint') 
+#    voltage_rbv = C(EpicsSignalRO, ':ActualVoltage')
+#    current_setpoint = C(EpicsSignal, ':CurrentSetPoint') 
+#    current_rbv = C(EpicsSignalRO, ':ActualCurrent')
+#    reset = C(EpicsSignal, ':ResetTDK')
+#
+#    def enable(self):
+#        """Enable the output of the TDK Lambda power supply."""
+#        self.enable.put(1)
+#    
+#    def disable(self):
+#        """Disable the output of the TDK Lambda power supply."""
+#        self.enable.put(0)
+#
+#    def set_voltage(self, voltage):
+#        """Change the voltage setpoint of the power supply."""
+#        self.voltage_setpoint.put(voltage)
+#
+#    def set_current(self, current):
+#        """Change the current setpoint of the power supply."""
+#        self.current_setpoint.put(current)
+#
+#    def reset(self):
+#        """Reset the power supply and place it in a safe condition."""
+#        self.reset.put(1)
+#
+#    @property
+#    def voltage(self):
+#        """Readback the current voltage output of the power supply."""
+#        volt = self.voltage_rbv.get()
+#        return volt
+#
+#    @property
+#    def current(self):
+#        """Readback of the current output of the power supply."""
+#        curr = self.current_rbv.get()
+#        return curr
+#
+#    @property
+#    def enabled(self):
+#        """Readback of the enable state of the power supply. True if enabled, 
+#        false otherwise."""
+#        state = self.enable_rbv.get()
+#        if state == 1:
+#            return True
+#        elif state == 0:
+#            return False
+#        else:
+#            print("Unknown enable state.")
+#
+#class EDrive(Device):
+#    """Class for the MEC EDrive power supply."""
+#
+#    # Epics Signals
+#    emission = C(EpicsSignal, ":Emission")
+#    emission_rbv = C(EpicsSignalRO, ":Emission_RBV")
+#    pulsewidth = C(EpicsSignal, ":PulseWidth")
+#    pulsewidth_rbv = C(EpicsSignalRO, ":PulseWidth_RBV")
+#    current = C(EpicsSignal, ":ActiveCurrent")
+#    current_rbv = C(EpicsSignalRO, ":SensedCurrent")
+#    voltage_rbv = C(EpicsSignalRO, ":PowerSupply")
+#    temp_rbv = C(EpicsSignalRO, ":Temperature")
+#    fault_status = C(EpicsSignalRO, ":FaultState")
+#
+#    def enable(self):
+#        """Enable the emission of the Edrive."""
+#        self.emission.put(1)
+#
+#    def disable(self):
+#        """Disable the emission of the Edrive."""
+#        self.emission.put(0)
+#
+#    def set_pulsewidth(self, width):
+#        """Set the pulsewidth of the Edrive."""
+#        self.pulsewidth.put(width)
+#
+#    def set_current(self, current):
+#        """Set the current output of the Edrive."""
+#        self.current.put(current)
+#
+#    @property
+#    def enabled(self):
+#        """Check the emission state of the Edrive. True if emission is on,
+#        False otherwise."""
+#        state = self.emission_rbv.get()
+#        return state
+#
+#    @property
+#    def pulsewidth(self):
+#        """Get the current pulsewidth of the Edrive."""
+#        width = self.pulsewidth_rbv.get()
+#        return width
+#
+#    @property
+#    def current(self):
+#        """Get the current output of the Edrive."""
+#        curr = self.current_rbv.get()
+#        return curr
+#        
+#    @property
+#    def voltage(self):
+#        """Get the voltage output of the Edrive."""
+#        volt = self.voltage_rbv.get()
+#        return volt
+#
+#    @property
+#    def temperature(self):
+#        """Get the temperature of the Edrive."""
+#        temp = self.temp_rbv.get()
+#        return temp
+#
+#    @property
+#    def fault_status(self):
+#        """Get the fault status of the Edrive."""
+#        fault = self.fault_status.get()
+#        return fault
+#
+#class IXBlueBiasGenerator(Device):
+#    """Class for MEC IX Blue laser bias controller."""
+#    
+#    # Epics signals
+#    bias = C(EpicsSignal, ":BiasValue")
+#    bias_rbv = C(EpicsSignalRO, ":BiasValue_RBV")
+#    run_mode = C(EpicsSignal, ":RunningMode")
+#    run_mode_rbv = C(EpicsSignalRO, ":RunningMode_RBV")
+#    scan_restart = C(EpicsSignal, ":ScanRestart")
+#    auto_calibration = C(EpicsSignal, ":AutoCalibration")
+#    comm_enable = C(EpicsSignal, ":COMM:ENABLE")
+#    error_status = C(EpicsSignalRO, ":ErrorStatus")
+#
+#    def set_bias(self, bias):
+#        """Set the bias value of the bias controller (in mV)."""
+#        self.bias.put(bias)
+#
+#    def set_mode(self, mode):
+#        """Set the run mode of the bias controller (AUTO or MAN)."""
+#        self.run_mode.put(mode)
+#
+#    def restart_scan(self):
+#        """Restart the bias scan."""
+#        self.scan_restart.put(1)
+#
+#    def set_calibration(self, cal):
+#        """Set the calibration mode. Can be QUAD, MIN, or MAX."""
+#        self.auto_calibration.put(cal)
+#
+#    def enable_com(self):
+#        """Enable remote communication."""
+#        self.comm_enable.put(1)
+#
+#    def disable_com(self):
+#        """Disable remote communication."""
+#        self.comm_enable.put(0)
+#
+#    @property
+#    def bias(self):
+#        """Return the current bias in mV."""
+#        volt = self.bias_rbv.get()
+#        return volt
+#
+#    @property
+#    def run_mode(self):
+#        """Return the run mode of the bias controller."""
+#        mode = self.run_mode_rbv.get()
+#        return mode
+#
+#    @property
+#    def error_status(self):
+#        """Return the error status of the bias controller."""
+#        error = self.error_status.get()
+#        return error
+#
+#
+
+class PU610K_Channel(Device):
+    """Class for the MEC PU610K PFN charging system channels."""
+
+    _enabled = C(EpicsSignalRO, ':ENABLE_RBV')
+    _enable  = C(EpicsSignal,   ':ENABLE')
+    _desc    = C(EpicsSignalRO, ':NAME')
+    _vset    = C(EpicsSignal,   ':VOLTAGE')
+    _vget    = C(EpicsSignalRO, ':VOLTAGE_MEASURED')
+    _inh     = C(EpicsSignal,   ':CHARGE_INHIBIT')
+    _inh_RBV = C(EpicsSignalRO, ':CHARGE_INHIBIT_RBV')
+    _cntdown = C(EpicsSignal,   ':CI_COUNTDOWN')
+    _state   = C(EpicsSignalRO, ':CHARGE_STATE')
+    _status  = C(EpicsSignalRO, ':ERRORMSG')
+
+    @property
+    def enabled(self):
+        rbv = self._enabled.get()
+        if rbv == 'Enabled':
+            return True
+        else:
+            return False
+
+    def enable(self):
+        self._enable.put(1)
+
+    def disable(self):
+        self._enable.put(0)
+
+    @property
+    def chan_name(self):
+        return self._desc.get()
+
+    @property
+    def voltage(self):
+        return self._vget.get()
+
+    @voltage.setter
+    def voltage(self, value):
+        self._vset.put(value)
+
+    @property
+    def charge_inhibit(self):
+        return self._inh_RBV.get()
+
+    @charge_inhibit.setter
+    def charge_inhibit(self, value):
+        self._inh.put(value)
+    
+    @property
+    def countdown(self):
+        return self._cntdown.get()
+
+    @countdown.setter
+    def countdown(self, value):
+        self._countdown.put(value)
+
+    @property
+    def state(self):
+        state_dict = {0: 'Not Charging',
+                      1: 'Charging',
+                      2: 'Charged'}
+        return state_dict[self._state.get()]
+
+    @property
+    def status(self):
+        return self._status.get()
+ 
+class PU610K(Device):
+    """Class for the MEC PFN charging racks."""
+    _charge = C(EpicsSignal, ':START_CHARGE')
+    _mode = C(EpicsSignal, ':MODE')
+    _mode_rbv = C(EpicsSignalRO, ':MODE_RBV')
+    _mode_ok = C(EpicsSignalRO, ':MODE_OK')
+    _fault = C(EpicsSignal, ':FAULT')
+    _charge_ok = C(EpicsSignalRO, ':CHARGE_OK')
+    _wp_ab = wp_ab
+    _wp_ef = wp_ef
+    _wp_gh = wp_gh
+    _wp_ij = wp_ij
+
+    __chancd = C(PU610K_Channel, ':CH0')
+    __chana =  C(PU610K_Channel, ':CH1')
+    __chanb =  C(PU610K_Channel, ':CH2')
+    __chane =  C(PU610K_Channel, ':CH3')
+    __chanf =  C(PU610K_Channel, ':CH4')
+    __chang =  C(PU610K_Channel, ':CH5')
+    __chanh =  C(PU610K_Channel, ':CH6')
+    __chani =  C(PU610K_Channel, ':CH7')
+    __chanj =  C(PU610K_Channel, ':CH8')
+
+    @property
+    def charged(self):
+        c = self._charge_ok.get()
+        if c == 0:
+            return False
+        elif c == 1:
+            return True
+        else:
+            raise Exception("Unknown PFN charge state: {}".format(c))
+
+    @property
+    def faulted(self):
+        f = self._fault.get()
+        if c == 1:
+            return True
+        else:
+            return False
+
+    @property
+    def ready(self):
+        mode_rbv = self._mode_rbv.get() 
+        mode_ok = self._mode_ok.get()
+        if (mode_rbv == 2) and (mode_ok == 0):
+            return True
+        else:
+            return False   
+
+    @property
+    def stand_by(self):
+        mode_rbv = self._mode_rbv.get() 
+        mode_ok = self._mode_ok.get()
+        if (mode_rbv == 1) and (mode_ok == 0):
+            return True
+        else:
+            return False 
+  
+    @property
+    def stopped(self):
+        mode_rbv = self._mode_rbv.get() 
+        mode_ok = self._mode_ok.get()
+        if (mode_rbv == 0) and (mode_ok == 0):
+            return True
+        else:
+            return False 
+  
+    def charge(self):
+        """Charge the PFN racks based on current settings."""
+
+        self._mode.put(0) # First go to stop to clear any errors
+        while not self.stopped:
+            time.sleep(0.1)
+
+        self._mode.put(1) # Now go to standby to start cooling
+        while not self.standby:
+            time.sleep(0.1)
+
+        self._mode.put(2) # now go to "ready" and wait. Requires at least
+                          # a 5 second delay (HW 'feature').  
+        while not self.ready:
+            time.sleep(0.1)
+
+        self._charge.put(1)
+        print("Charging, please wait ...")
+        while not self.charged:
+            time.sleep(1)
+        print("Charging complete!")
+
+    def discharge(self):
+        """Discharge the PFN racks."""
+        self.mode.put(0)
+
+    def ALL(self):
+        self.__chancd.enable()
+        self.__chang.enable()
+        self.__chanh.enable()
+        self.__chani.enable()
+        self.__chanj.enable()
+        self.__chana.enable()
+        self.__chanb.enable()
+        self.__chane.enable()
+        self.__chanf.enable()
+        self._wp_ab.mv_on()
+        self._wp_ef.mv_on()
+        self._wp_gh.mv_on()
+        self._wp_ij.mv_on()
+
+    def ALL_OFF(self):
+        self.__chancd.disable()
+        self.__chang.disable()
+        self.__chanh.disable()
+        self.__chani.disable()
+        self.__chanj.disable()
+        self.__chana.disable()
+        self.__chanb.disable()
+        self.__chane.disable()
+        self.__chanf.disable()
+        self._wp_ab.mv_off()
+        self._wp_ef.mv_off()
+        self._wp_gh.mv_off()
+        self._wp_ij.mv_off()
+
+    def GHIJ(self):
+        """Enable the GHIJ arms, disable ABEF arms."""
+        self.__chancd.enable()
+        self.__chang.enable()
+        self.__chanh.enable()
+        self.__chani.enable()
+        self.__chanj.enable()
+        self.__chana.disable()
+        self.__chanb.disable()
+        self.__chane.disable()
+        self.__chanf.disable()
+        self._wp_ab.mv_off()
+        self._wp_ef.mv_off()
+        self._wp_gh.mv_on()
+        self._wp_ij.mv_on()
+
+    def ABEF(self):
+        """Enable the ABEF arms, disable GHIJ arms."""
+        self.__chancd.enable()
+        self.__chana.enable()
+        self.__chanb.enable()
+        self.__chane.enable()
+        self.__chanf.enable()
+        self.__chang.disable()
+        self.__chanh.disable()
+        self.__chani.disable()
+        self.__chanj.disable()
+        self._wp_ab.mv_on()
+        self._wp_ef.mv_on()
+        self._wp_gh.mv_off()
+        self._wp_ij.mv_off()

--- a/mec/sequence.py
+++ b/mec/sequence.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python
+#
+# Module for setting up the MEC event sequencer
+#
+
+def generateSequence(code_list, total_beamdelta):
+    """Generate a sequence given a list of lists containing event codes, and
+    the requested beam deltas from the event for that code. 
+
+    Parameters
+    ----------
+    code_list : list
+        list of lists containing beam codes and desired total beam delta from
+        the xray event for that code. Example:
+        list = [[<eventcode>, <beamdelta>], [<eventcode>, <beamdelta>], ... ]
+
+    total_beamdelta : int
+        The number of beam deltas for the sync marker that you are using. For
+        example, a sync marker of 5Hz would have 120/5 = 24 beam deltas.
+    """
+    # Sort codes based on delta from beam event
+    sorted_codes = sorted(code_list, key=lambda code: code[1])
+
+    # Generate sequence, assigning beam delta using the beam delta from
+    # the next code (the delta of the delta?)
+    sorted_seq = []
+    for i in range(len(sorted_codes)-1):
+        sorted_bd = sorted_codes[i+1][1] - sorted_codes[i][1]
+        sorted_seq.append([sorted_codes[i][0], sorted_bd, 0, 0])
+
+    # Deal with any codes that have the same beam delta by making the first
+    # code have zero beam delta. This makes them occur (almost) simultaneously.
+    for i in range(len(sorted_codes)-1):
+        code1_bd = sorted_codes[i][1]
+        code2_bd = sorted_codes[i+1][1]
+
+        if code1_bd == code2_bd:
+            sorted_codes[i][1] = 0
+
+    # Get the maximum beam delta needed by codes
+    max_beamdelta = max([code[1] for code in sorted_codes])
+
+    # Check that the whole sequence will fit in one sync marker
+    # TODO: Update function so this isn't a problem? Can that be done?
+    if max_beamdelta > total_beamdelta:
+        raise Exception("The maximum event code beam delta exceeds the sync "
+                        "marker! Please edit your sequence.")
+
+    # Add the last code (furthest away from the event) with the remaining beam
+    # delta.
+    last_beamdelta = total_beamdelta - max_beamdelta
+    sorted_seq.append([sorted_codes[-1][0], last_beamdelta, 0, 0])
+
+    # Reverse the list to give a sequence that is in the same order as it will
+    # be applied to the event sequencer
+    seq = list(reversed(sorted_seq)) 
+
+    return seq
+
+class Sequence:
+    """Class for defining event sequences for the MEC instrument."""
+    def __init__(self):
+        # MEC event code defs
+        self.EC = {'slowcam':      167,
+                   'pulsepicker':  168,
+                   'daqreadout':   169,
+                   'prelaser':     170,
+                   'postlaser':    171,
+                   'shortpulse':   176,
+                   'prelasertrig': 177,
+                   'longpulse':    182}
+
+        # Initialize config
+        self.prelasertrig = 0
+        self.slowcam = False 
+        self.slowcamdelay = 5
+        self.rate = 5
+
+    @property
+    def config(self):
+        conf = {'rate': self.rate,
+                'prelasertrig': self.prelasertrig,
+                'slowcam': self.slowcam,
+                'slowcamdelay': self.slowcamdelay}
+
+        return conf
+
+    def configure(self, Rate=5, PreLaserTrig=0, SlowCam=False, SlowCamDelay=5):
+        """Configure the sequencer for the given parameters.
+
+        configure(self, Rate=5, PreLaserTrig=0, SlowCam=False, SlowCamDelay=5):
+
+        Parameters
+        ----------
+        rate : int
+            Integer rate at which you want to take laser shots, with or without
+            x-rays, synchronized to the XFEL.
+
+        PreLaserTrig : int
+            Add a pre-laser trigger to the experimental ('During') sequence
+            that occurs N x 8.4 ms before the laser shot. Used to trigger slow 
+            diagnostics, shutters, etc.
+
+        SlowCam : bool
+            Add the slow cameras (i.e. PI-MTEs, Pixis) to the sequence.
+
+        SlowCamDelay : int
+            The number of beam codes to delay the sequence to allow the slow
+            cameras to open their shutters.
+        """
+
+        # Requested config 
+        self.prelasertrig = int(PreLaserTrig)
+        self.slowcam = SlowCam
+        self.slowcamdelay = SlowCamDelay
+        self.rate = int(Rate)
+
+
+    def darkSequence(self, nshots, preshot=True):
+        """Setup a dark sequence (no XFEL, no optical laser).
+
+        darkSequence(preshot=True)
+
+        Parameters
+        ----------
+        nshots : int
+            The number of events to take during the dark sequence.
+
+        preshot : bool
+            Set the mark event code. Uses pre-shot (EC 170) if True, 
+            post-shot (EC 171) if false.
+        """
+
+        seq = []
+
+        bd = int(120/self.rate) # Beam deltas
+
+        # Decide what marker to use
+        if preshot:
+            mark = self.EC['prelaser']
+        else:
+            mark = self.EC['postlaser']
+
+        # Setup first shot
+        eventcodes = []
+        eventcodes.append([self.EC['daqreadout'], 0])
+        eventcodes.append([mark, 0])
+        if self.slowcam:
+            eventcodes.append([self.EC['slowcam'], self.slowcamdelay])
+        if self.prelasertrig > 0:
+            eventcodes.append([self.EC['prelasertrig'], self.prelasertrig])
+
+        seq = generateSequence(eventcodes, bd)
+
+        if nshots > 1:
+            # Create sequence for all but last shot
+            eventcodes = []
+            eventcodes.append([self.EC['daqreadout'], 0])
+            eventcodes.append([mark, 0])
+            if self.prelasertrig > 0:
+                eventcodes.append([self.EC['prelasertrig'], self.prelasertrig])
+
+            s = generateSequence(eventcodes, bd)
+            s *= nshots-1
+            seq += s
+
+            #seq += generateSequence(eventcodes, bd)
+
+        return seq
+
+    def darkXraySequence(self, nshots, preshot=True):
+        """Setup a dark X-ray sequence (XFEL only, no optical laser).
+
+        darkXraySequence(nshots, preshot=True)
+
+        Parameters
+        ----------
+        nshots : int
+            The number of events to take during the dark sequence.
+
+        preshot : bool
+            Set the mark event code. Uses pre-shot (EC 170) if True, 
+            post-shot (EC 171) if false.
+        """
+
+        seq = []
+
+        bd = int(120/self.rate) # Beam deltas per xray shot
+
+        # Decide what marker to use
+        if preshot:
+            mark = self.EC['prelaser'] 
+        else:
+            mark = self.EC['postlaser']
+
+        # Setup first shot
+        eventcodes = []
+        eventcodes.append([self.EC['pulsepicker'], 2])
+        eventcodes.append([mark, 0])
+        eventcodes.append([self.EC['daqreadout'], 0])
+        if self.slowcam:
+            eventcodes.append([self.EC['slowcam'], self.slowcamdelay])
+        if self.prelasertrig > 0:
+            eventcodes.append([self.EC['prelasertrig'], self.prelasertrig])
+
+        seq = generateSequence(eventcodes, bd)
+
+        if nshots > 1:
+            # Create sequence for all but last shot
+            eventcodes = []
+            eventcodes.append([self.EC['pulsepicker'], 2])
+            eventcodes.append([mark, 0])
+            eventcodes.append([self.EC['daqreadout'], 0])
+            if self.prelasertrig > 0:
+                eventcodes.append([self.EC['prelasertrig'], self.prelasertrig])
+
+            s = generateSequence(eventcodes, bd)
+            s *= nshots-2
+            seq += s
+
+            # Add in the last shot
+            eventcodes = []
+            eventcodes.append([self.EC['pulsepicker'], 1])
+            eventcodes.append([mark, 0])
+            eventcodes.append([self.EC['daqreadout'], 0])
+            if self.prelasertrig > 0:
+                eventcodes.append([self.EC['prelasertrig'], self.prelasertrig])
+
+            seq += generateSequence(eventcodes, bd)
+
+        return seq
+
+    def opticalSequence(self, nshots, laser, preshot=True):
+        """Set up an optical laser sequence (no XFEL, optical laser only).
+
+        opticalSequence(nshots, laser, preshot=True)
+
+        Parameters
+        ----------
+        nshots : int
+            The number of events to take during the optical sequence.
+
+        laser : str
+            Select which laser you want to fire. 'longpulse' for NS laser,
+            'shortpulse' for FS laser.
+
+        preshot : bool
+            Set the mark event code. Uses pre-shot (EC 170) if True, 
+            post-shot (EC 171) if false.
+        """
+
+        if laser != 'longpulse' and laser != 'shortpulse':
+            raise Exception("Unrecognized laser requested: {}".format(laser))
+
+        if laser == 'longpulse' and nshots > 1:
+            m = ("Cannot take more than one shot with the long pulse laser! "
+                "Please set the number of shots to 1.")
+            raise Exception(m)
+
+        lasercode = self.EC[laser]
+
+        seq = []
+
+        bd = int(120/self.rate) # Beam deltas per xray shot
+
+        # Decide what marker to use
+        if preshot:
+            mark = self.EC['prelaser'] 
+        else:
+            mark = self.EC['postlaser']
+           
+        # Setup first shot
+        eventcodes = []
+        eventcodes.append([self.EC['daqreadout'], 0])
+        eventcodes.append([lasercode, 0])
+        eventcodes.append([mark, 0])
+        if self.slowcam:
+            eventcodes.append([self.EC['slowcam'], self.slowcamdelay])
+        if self.prelasertrig > 0:
+            eventcodes.append([self.EC['prelasertrig'], self.prelasertrig])
+
+        seq = generateSequence(eventcodes, bd)
+
+        if nshots > 1:
+            # Create sequence for all but last shot
+            eventcodes = []
+            eventcodes.append([self.EC['daqreadout'], 0])
+            eventcodes.append([lasercode, 0])
+            eventcodes.append([mark, 0])
+            if self.prelasertrig > 0:
+                eventcodes.append([self.EC['prelasertrig'], self.prelasertrig])
+
+            s = generateSequence(eventcodes, bd)
+            s *= nshots-1
+            seq += s
+
+        return seq
+
+    def duringSequence(self, nshots, laser):
+        """Setup a 'during' sequence (optical laser + XFEL).
+
+        """
+        bd = int(120/self.rate) # Beam deltas per laser shot
+
+        if laser != 'longpulse' and laser != 'shortpulse':
+            raise Exception("Unrecognized laser requested: {}".format(laser))
+
+        if laser == 'longpulse' and nshots > 1:
+            m = ("Cannot take more than one shot with the long pulse laser! "
+                "Please set the number of shots to 1.")
+            raise Exception(m)
+
+        lasercode = self.EC[laser]
+
+        # Setup first shot
+        eventcodes = []
+        eventcodes.append([self.EC['pulsepicker'], 2])
+        eventcodes.append([self.EC['daqreadout'], 0])
+        eventcodes.append([lasercode, 0])
+        if self.slowcam:
+            eventcodes.append([self.EC['slowcam'], self.slowcamdelay])
+        if self.prelasertrig > 0:
+            eventcodes.append([self.EC['prelasertrig'], self.prelasertrig])
+
+        seq = generateSequence(eventcodes, bd)
+
+        if nshots > 1:
+            # Create sequence for all but last shot
+            eventcodes = []
+            eventcodes.append([self.EC['pulsepicker'], 2])
+            eventcodes.append([self.EC['daqreadout'], 0])
+            eventcodes.append([lasercode, 0])
+            if self.prelasertrig > 0:
+                eventcodes.append([self.EC['prelasertrig'], self.prelasertrig])
+
+            s = generateSequence(eventcodes, bd)
+            s *= nshots-2
+            seq += s
+
+            # Add in the last shot
+            eventcodes = []
+            eventcodes.append([self.EC['pulsepicker'], 1])
+            eventcodes.append([self.EC['daqreadout'], 0])
+            eventcodes.append([lasercode, 0])
+            if self.prelasertrig > 0:
+                eventcodes.append([self.EC['prelasertrig'], self.prelasertrig])
+
+            seq += generateSequence(eventcodes, bd)
+            
+        return seq
+

--- a/mec/spl_modes.py
+++ b/mec/spl_modes.py
@@ -1,0 +1,16 @@
+from ophyd import (Device, EpicsSignal, EpicsSignalRO, Component as C,
+                   FormattedComponent as FC)
+
+class DG645(Device):
+    """Barebones class for managing DG645 for MEC Uniblitz deployment."""
+    
+    # EPICS Signals
+    ch_AB_pol = C(EpicsSignal, ':abOutputPolarityBO.VAL')
+    ch_CD_pol = C(EpicsSignal, ':cdOutputPolarityBO.VAL')
+
+class UniblitzEVRCH(Device):
+    """Barebones class for managing EVR channels for MEC Uniblitz deployment."""
+    
+    # EPICS Signals
+    ch_enable = C(EpicsSignal, ':TCTL')
+    ch_eventc = C(EpicsSignal, ':TEC')

--- a/mecenv
+++ b/mecenv
@@ -1,6 +1,22 @@
 #!/bin/bash
 # Source this to load the full environment that hutch python uses
+#HERE=`dirname $(readlink -f $0)`
+#source "${HERE}/mecversion"
+#pathmunge "${CONDA_BASE}/bin"
+#source activate "${CONDA_ENVNAME}"
+##source pcdsdaq_lib_setup
+
+# edit this line only
+export CONDA_ENVNAME="pcds-2.0.1"
+export CONDA_BASE="/reg/g/pcds/pyps/conda/py36"
+export HUTCH="mec"
+
+unset PYTHONPATH
+unset LD_LIBRARY_PATH
+
+source "${CONDA_BASE}/etc/profile.d/conda.sh"
+conda activate "${CONDA_ENVNAME}"
 HERE=`dirname $(readlink -f $0)`
-source "${HERE}/mecversion"
-pathmunge "${CONDA_BASE}/bin"
-source activate "${CONDA_ENVNAME}"
+export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdevices"
+source pcdsdaq_lib_setup
+export CONDA_PROMPT_MODIFIER="(${HUTCH}-${CONDA_ENVNAME})"

--- a/mecenv
+++ b/mecenv
@@ -12,6 +12,7 @@ unset LD_LIBRARY_PATH
 source "${CONDA_BASE}/etc/profile.d/conda.sh"
 conda activate "${CONDA_ENVNAME}"
 HERE=`dirname $(readlink -f $0)`
-export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdevices"
+export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdevices:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdaq"
+#export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdevices"
 source pcdsdaq_lib_setup
 export CONDA_PROMPT_MODIFIER="(${HUTCH}-${CONDA_ENVNAME})"

--- a/mecenv
+++ b/mecenv
@@ -1,10 +1,5 @@
 #!/bin/bash
 # Source this to load the full environment that hutch python uses
-#HERE=`dirname $(readlink -f $0)`
-#source "${HERE}/mecversion"
-#pathmunge "${CONDA_BASE}/bin"
-#source activate "${CONDA_ENVNAME}"
-##source pcdsdaq_lib_setup
 
 # edit this line only
 export CONDA_ENVNAME="pcds-2.0.1"

--- a/mecpython
+++ b/mecpython
@@ -1,8 +1,5 @@
 #!/bin/bash
 # Launch hutch-python with all devices
 HERE=`dirname $(readlink -f $0)`
-#source "${HERE}/mecversion"
 source "${HERE}/mecenv"
-#pathmunge "${CONDA_BIN}"
-#source pcdsdaq_lib_setup
 hutch-python --cfg "${HERE}/conf.yml" $@

--- a/mecpython
+++ b/mecpython
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Launch hutch-python with all devices
 HERE=`dirname $(readlink -f $0)`
-source "${HERE}/mecversion"
-pathmunge "${CONDA_BIN}"
+#source "${HERE}/mecversion"
+source "${HERE}/mecenv"
+#pathmunge "${CONDA_BIN}"
+#source pcdsdaq_lib_setup
 hutch-python --cfg "${HERE}/conf.yml" $@

--- a/mecversion
+++ b/mecversion
@@ -3,14 +3,16 @@
 # This is referenced by the three launcher scripts.
 
 # edit this line only
-export CONDA_ENVNAME='pcds-1.2.0'
+#export CONDA_ENVNAME='pcds-1.2.6'
+export CONDA_ENVNAME='pcds-2.0.1'
 
 export CONDA_BASE='/reg/g/pcds/pyps/conda/py36'
 export CONDA_ENV="${CONDA_BASE}/envs/${CONDA_ENVNAME}"
 export CONDA_BIN="${CONDA_ENV}/bin/wrappers/conda"
 
 HERE=`dirname $(readlink -f $0)`
-export PYTHONPATH="${HERE}:${HERE}/dev/devpath"
+#export PYTHONPATH="${HERE}:${HERE}/dev/devpath"
+export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdevices"
 export LD_LIBRARY_PATH=''
 
 source /reg/g/pcds/setup/pathmunge.sh


### PR DESCRIPTION
Pulling in lots of code developed for generating the appropriate sequences for MEC to run the long pulse laser and short pulse laser, as well as the Ophyd objects and BlueSky plans to do so. 

Notes:
------
-laser.py: main module for controlling the MEC lasers. Includes SPL
    and LPL
-laser_devices.py: module containing laser Ophyd devices.
-sequence.py: module for creating appropriate sequences for the
    event sequencer
-spl_modes.py: module with macros for switching the SPL between
    different modes of operations
-devices.py: added new non-laser related Ophyd devices and macros
-beamline.py: added new laser and non-laser Ophyd devices
-mecenv: updated some paths to local checkouts of other repos. Once
    the changes I have made there have been adopted and released,
    we can switch these to production paths.